### PR TITLE
#103 Orientation changes crashes app

### DIFF
--- a/AndroidStealth/src/main/AndroidManifest.xml
+++ b/AndroidStealth/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
 			android:label="@string/app_name"
 			android:launchMode="singleTop"
 			android:uiOptions="splitActionBarWhenNarrow"
+			android:configChanges="orientation|keyboardHidden"
 			android:excludeFromRecents="true" >
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />

--- a/AndroidStealth/src/main/java/com/stealth/android/HomeActivity.java
+++ b/AndroidStealth/src/main/java/com/stealth/android/HomeActivity.java
@@ -4,6 +4,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.widget.DrawerLayout;
@@ -95,6 +96,12 @@ public class HomeActivity extends ActionBarActivity
 			pm.setComponentEnabledSetting(homeName, PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
 					PackageManager.DONT_KILL_APP);
 		}
+	}
+
+	@Override
+	public void onConfigurationChanged(Configuration newConfig) {
+		super.onConfigurationChanged(newConfig);
+		//reload your ScrollBars by checking the newConfig
 	}
 
 	/**


### PR DESCRIPTION
Added config change entry to manifest to let our app listen to orientation changes instead of letting android restart our app. Issue not fixed though. See #103
