### PR TITLE
#124 Tap to lock fix

### DIFF
--- a/AndroidStealth/src/main/AndroidManifest.xml
+++ b/AndroidStealth/src/main/AndroidManifest.xml
@@ -51,7 +51,12 @@
 			</intent-filter>
 		</receiver>
 
-		<service android:name="encryption.EncryptionService" />
+		<service android:name="encryption.EncryptionService"
+				android:exported="false">
+			<intent-filter>
+				<action android:name="encryption.EncryptionService.TAP_TO_LOCK" />
+			</intent-filter>
+		</service>
 		<activity
 			android:name="com.ipaulpro.afilechooser.FileChooserActivity"
 			android:enabled="@bool/use_activity"

--- a/AndroidStealth/src/main/java/encryption/EncryptionService.java
+++ b/AndroidStealth/src/main/java/encryption/EncryptionService.java
@@ -28,6 +28,7 @@ import spikes.notifications.FileStatusNotificationsManager;
  */
 public class EncryptionService extends Service implements FileIndex.OnFileIndexChangedListener {
 
+	public static final String TAP_TO_LOCK = "tapToLock";
 	private static final int POOL_SIZE = 10;
 
 	private HashMap<String, CryptoTask> mToEncrypt = new HashMap<String, CryptoTask>();
@@ -71,7 +72,7 @@ public class EncryptionService extends Service implements FileIndex.OnFileIndexC
 
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
-		if (intent.getAction() != null && intent.getAction().equals(FileStatusNotificationsManager.ACTION_LOCK_ALL)) {
+		if (intent.getAction() != null && intent.getAction().equals(TAP_TO_LOCK)) {
 			Utils.d("You tapped to lock. Will do!");
 			EncryptionManager.create(this).encryptItems(FileIndex.get().getUnlockedFiles(), null);
 			return super.onStartCommand(intent, flags, startId);

--- a/AndroidStealth/src/main/java/spikes/notifications/FileStatusNotificationsManager.java
+++ b/AndroidStealth/src/main/java/spikes/notifications/FileStatusNotificationsManager.java
@@ -17,8 +17,6 @@ import encryption.EncryptionService;
  */
 public class FileStatusNotificationsManager {
 
-	public static final String ACTION_LOCK_ALL = "lockAllItems";
-
 	private static FileStatusNotificationsManager sInstance = null;
 	public static FileStatusNotificationsManager get() {
 		if (sInstance == null) {
@@ -165,7 +163,7 @@ public class FileStatusNotificationsManager {
 	{
 		// Creates an explicit intent for an Activity in your app
 		Intent resultIntent = new Intent(mContext, EncryptionService.class);
-		resultIntent.setAction(ACTION_LOCK_ALL);
+		resultIntent.setAction(EncryptionService.TAP_TO_LOCK);
 		return PendingIntent.getService(Utils.getContext(), 0, resultIntent, 0);
 	}
 }


### PR DESCRIPTION
Sometimes tap to lock still doesn't work. Intent filter was missing and service was public. Made it private and now listens properly to the correct intent.
