### PR TITLE
Update gradle files ignores new build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ local.properties
 /*/local.properties
 /*/out
 /*/*/build
+build/
 /*/*/production
 *.iml
 *.iws

--- a/AndroidStealth/build.gradle
+++ b/AndroidStealth/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion '19.1.0'
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 19

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:0.12.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 03 08:36:29 CEST 2014
+#Mon Sep 08 15:01:24 CEST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/libraries/FileChooser/build.gradle
+++ b/libraries/FileChooser/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:0.12.2'
     }
 }
 apply plugin: 'android-library'
@@ -16,7 +16,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion '19.1.0'
 
     sourceSets {
         main {


### PR DESCRIPTION
Gradle files have been updated through the upgrade tools in Android
Studio.

.gitignore has been updated to exclude new build files.

closes #210 
