### PR TITLE
Removed title style padding and boldness

### DIFF
--- a/AndroidStealth/src/main/res/values/styles.xml
+++ b/AndroidStealth/src/main/res/values/styles.xml
@@ -14,7 +14,6 @@
 		<item name="android:tag">@string/font_bold_condensed</item>
 		<item name="android:textSize">@dimen/text_largest</item>
 		<item name="android:textColor">@color/accent</item>
-		<item name="android:textStyle">bold</item>
 	</style>
 
 	<style name="SubTitle">


### PR DESCRIPTION
Closes #223, issue was present in all dialogs.
Closes #221, too. @OlivierHokke please review the current results, although you were right about the duplicate bolding I couldn't reproduce the clipping of the text.
Fixes #220 as well

@droidstealth/developers ready for review. I specifically want a thumbs-up from @OlivierHokke too.
